### PR TITLE
セキュリティアップデート

### DIFF
--- a/.env.FindMsg
+++ b/.env.FindMsg
@@ -1,0 +1,41 @@
+# Package name of the Microsoft Teams application
+PACKAGE_NAME=FindMsg
+
+# Application Name
+APP_NAME=Message Finder
+
+# The domain name of where you host your application
+HOSTNAME=cuehirai.github.io
+
+# Logo image source for the ABOUT page
+LOGO=https://static2.sharepointonline.com/files/fabric/assets/brand-icons/product-fluent/svg/teams_48x1.svg
+
+# Id of the Microsoft Teams application
+APPLICATION_ID=2e9f73d3-65f6-4ed6-8fbb-6ec025d9cde7
+
+# Application Insights instrumentation key
+APPINSIGHTS_INSTRUMENTATIONKEY=0b53b004-005f-46be-8fc1-63b98d9654e4
+
+# App Id and App Password for the Bot Framework bot
+MICROSOFT_APP_ID=
+MICROSOFT_APP_PASSWORD=
+
+# Port for local debugging
+PORT=3007
+
+# Security token for the default outgoing webhook
+SECURITY_TOKEN=
+
+# ID of the Outlook Connector
+CONNECTOR_ID=
+
+# NGROK configuration for development
+# NGROK authentication token (leave empty for anonymous)
+NGROK_AUTH=
+# NGROK sub domain. ex "myapp" or  (leave empty for random)
+NGROK_SUBDOMAIN=
+# NGROK region. (us, eu, au, ap - default is us)
+NGROK_REGION=
+
+# Debug settings, default logging "msteams"
+DEBUG=msteams

--- a/.env.SeaChaSt
+++ b/.env.SeaChaSt
@@ -1,0 +1,41 @@
+# Package name of the Microsoft Teams application
+PACKAGE_NAME=SeaChaSt
+
+# Application Name
+APP_NAME=SeaChaSt
+
+# The domain name of where you host your application
+HOSTNAME=seachast.azurewebsites.net
+
+# Logo image source for the ABOUT page
+LOGO=https://static2.sharepointonline.com/files/fabric/assets/brand-icons/product-fluent/svg/teams_48x1.svg
+
+# Id of the Microsoft Teams application
+APPLICATION_ID=6f5036ec-ad6d-4b29-87cb-010b0702bce4
+
+# Application Insights instrumentation key
+APPINSIGHTS_INSTRUMENTATIONKEY=474f6161-5de0-419b-baa4-9d57b2abdb37
+
+# App Id and App Password for the Bot Framework bot
+MICROSOFT_APP_ID=
+MICROSOFT_APP_PASSWORD=
+
+# Port for local debugging
+PORT=3007
+
+# Security token for the default outgoing webhook
+SECURITY_TOKEN=
+
+# ID of the Outlook Connector
+CONNECTOR_ID=
+
+# NGROK configuration for development
+# NGROK authentication token (leave empty for anonymous)
+NGROK_AUTH=
+# NGROK sub domain. ex "myapp" or  (leave empty for random)
+NGROK_SUBDOMAIN=
+# NGROK region. (us, eu, au, ap - default is us)
+NGROK_REGION=
+
+# Debug settings, default logging "msteams"
+DEBUG=msteams

--- a/gulp.config.js
+++ b/gulp.config.js
@@ -51,7 +51,7 @@ const config = {
     }
     ],
     // This is the name of the packaged manifest file
-    manifestFileName: "FindMsg.zip"
+    manifestFileName: "manifest.zip"
 };
 
 module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7606,6 +7606,11 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
+    "indexeddb-export-import": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/indexeddb-export-import/-/indexeddb-export-import-2.1.2.tgz",
+      "integrity": "sha512-IhN4PYAye54qjGaAeiMcs9aYstYFX9SyxxAChpc6zuq2G2qsAVmaxOPLBigHP27oKJn5LgbZS2R2ZzUoEuj/TA=="
+    },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "express": "4.17.1",
     "express-msteams-host": "1.6.2",
     "express-session": "1.17.1",
+    "indexeddb-export-import": "^2.1.2",
     "mark.js": "^8.11.1",
     "morgan": "1.10.0",
     "office-ui-fabric-react": "^7.144.0",

--- a/src/app/TeamsAppsComponents.ts
+++ b/src/app/TeamsAppsComponents.ts
@@ -6,4 +6,7 @@ export * from "./FindMsgTopicsTab/FindMsgTopicsTab";
 export * from "./FindMsgSearchTab/FindMsgSearchTab";
 // Automatically added for the FindMsgSearchChat tab
 export * from "./FindMsgSearchChat/FindMsgSearchChat";
+// Automatically added for the FindMsgSearchSchedule tab
 export * from "./FindMsgSearchSchedule/FindMsgSearchSchedule";
+// Automatically added for the about page
+export * from "./about/FindMsgIndex";

--- a/src/app/about/FindMsgIndex.ts
+++ b/src/app/about/FindMsgIndex.ts
@@ -1,0 +1,8 @@
+import { PreventIframe } from "express-msteams-host";
+
+/**
+ * Used as place holder for the decorators
+ */
+@PreventIframe("/about/index.html")
+export class FindMsgIndex {
+}

--- a/src/app/scripts/FindMsgSearchSchedule/EventTable.tsx
+++ b/src/app/scripts/FindMsgSearchSchedule/EventTable.tsx
@@ -178,7 +178,7 @@ export const EventTable: React.FunctionComponent<IEventTableProps> = ({ translat
                 { key: 's', truncateContent: true, content: <Link onClick={() => msTeams.executeDeepLink(fixMessageLink(deeplink(id)), log.info)} disabled={!webLink}><ContentElement body={title(subject, notitle)} type="text" filter={filter} /></Link> },
                 { key: 'o', truncateContent: true, content: organizerWithAttendeeTooltip(organizerName, organizerMail, unknownUserDisplayName, attendees) },
                 { key: 't', truncateContent: false, content: stContent(start, end, isAllDay) },
-                { key: 'c', truncateContent: true, content: <ContentElement body={body} type={type} filter={filter} /> }
+                { key: 'c', truncateContent: true, content: <ContentElement body={body} type={type} filter={filter} tooltip={true}/> }
             ],
         });
 

--- a/src/app/scripts/FindMsgTopicsTab/FindMsgTopicsTab.tsx
+++ b/src/app/scripts/FindMsgTopicsTab/FindMsgTopicsTab.tsx
@@ -18,6 +18,7 @@ import { IMessageTranslation } from "../i18n/IMessageTranslation";
 import { AI } from '../appInsights';
 import { getTopLevelMessagesLastSynced } from "../db/Sync";
 import { getChannelMap, IChannelInfo } from "../ui-jsx";
+import { db } from "../db/Database";
 
 
 declare type DropdownItemPropsKey = DropdownItemProps & { key: string };
@@ -184,8 +185,10 @@ export class FindMsgTopicsTab extends TeamsBaseComponent<never, IFindMsgTopicsTa
             websiteUrl: location.href,
         });
 
+        await db.login(this.msGraphClient,loginHint);
+
         // add lastSynced for top level messages
-        const lastSynced = channelId ? await Sync.getChannelLastSynced(channelId) : getTopLevelMessagesLastSynced();
+        const lastSynced = channelId ? await Sync.getChannelLastSynced(channelId) : await getTopLevelMessagesLastSynced();
 
         let teamIdx: number;
         let channelIdx: number;
@@ -524,7 +527,7 @@ export class FindMsgTopicsTab extends TeamsBaseComponent<never, IFindMsgTopicsTa
             if (groupId && channelId) {
                 syncResult = await Sync.channelTopLevelMessages(this.msGraphClient, groupId, channelId, throwfn, this.reportProgress, syncProgress);
             } else {
-                syncResult = await Sync.autoSyncAll(this.msGraphClient, false, throwfn, this.reportProgress, syncProgress);
+                syncResult = await Sync.autoSyncAll(this.msGraphClient, false, throwfn, this.reportProgress, syncProgress, true);
             }
 
             if (syncResult) {

--- a/src/app/scripts/FindMsgTopicsTab/MessageTable.tsx
+++ b/src/app/scripts/FindMsgTopicsTab/MessageTable.tsx
@@ -7,9 +7,9 @@ import * as msTeams from '@microsoft/teams-js';
 import { format, isValid } from "../dateUtils";
 import { info } from '../logger'
 import { fixMessageLink } from "../utils";
-import { highlightNode, collapse, empty } from "../highlight";
-import { stripHtml } from "../purify";
-import { HtmlTooltip, IChannelInfo } from "../ui-jsx";
+// import { highlightNode, collapse, empty } from "../highlight";
+// import { stripHtml } from "../purify";
+import { ContentElement, HtmlTooltip, IChannelInfo } from "../ui-jsx";
 import { Typography } from "@material-ui/core";
 
 
@@ -88,11 +88,11 @@ const SortableHeader: (props: ISortableHeaderProps) => TableCellProps = ({ title
 };
 
 
-interface MessageContentProps {
-    body: string;
-    type: "text" | "html";
-    filter: string;
-}
+// interface MessageContentProps {
+//     body: string;
+//     type: "text" | "html";
+//     filter: string;
+// }
 
 interface ITeamChannelTooltipArg {
     authorName: string;
@@ -102,24 +102,24 @@ interface ITeamChannelTooltipArg {
     teamchannel: (teamname: string, channelname: string) => string;
 }
 
-const MessageContent: React.FunctionComponent<MessageContentProps> = ({ type, body, filter }: MessageContentProps) => {
-    const el = React.useRef<HTMLSpanElement>(null);
-    React.useEffect(() => {
-        if (!el.current) return;
-        empty(el.current);
-        const c = document.createElement("span");
-        if (type === "text") {
-            c.textContent = body;
-        } else {
-            // there is no more html, but still entities like &nbsp;
-            c.innerHTML = stripHtml(body);
-        }
-        const hasHighlight = highlightNode(c, [filter, ""]);
-        if (body.length > 30 && hasHighlight) collapse(c, 20, 6);
-        el.current.appendChild(c);
-    }, [type, body, filter]);
-    return <span ref={el} />
-}
+// const MessageContent: React.FunctionComponent<MessageContentProps> = ({ type, body, filter }: MessageContentProps) => {
+//     const el = React.useRef<HTMLSpanElement>(null);
+//     React.useEffect(() => {
+//         if (!el.current) return;
+//         empty(el.current);
+//         const c = document.createElement("span");
+//         if (type === "text") {
+//             c.textContent = body;
+//         } else {
+//             // there is no more html, but still entities like &nbsp;
+//             c.innerHTML = stripHtml(body);
+//         }
+//         const hasHighlight = highlightNode(c, [filter, ""]);
+//         if (body.length > 30 && hasHighlight) collapse(c, 20, 6);
+//         el.current.appendChild(c);
+//     }, [type, body, filter]);
+//     return <span ref={el} />
+// }
 
 
 /**
@@ -136,11 +136,11 @@ export const MessageTable: React.FunctionComponent<IMessageTableProps> = ({ t, m
         const MessageTableRow: (msg: IFindMsgChannelMessage) => TableRowProps = ({ id, subject, authorName, created, modified, body, type, url, channelId }) => ({
             key: id,
             items: [
-                { key: 's', truncateContent: true, content: <Link onClick={() => msTeams.executeDeepLink(fixMessageLink(url), info)} disabled={!url}><MessageContent body={subject ?? ""} type="text" filter={filter} /></Link> },
+                { key: 's', truncateContent: true, content: <Link onClick={() => msTeams.executeDeepLink(fixMessageLink(url), info)} disabled={!url}><ContentElement body={subject ?? ""} type="text" filter={filter} /></Link> },
                 // { key: 'a', truncateContent: true, content: authorName || unknownUserDisplayName },
                 { key: 'a', truncateContent: true, content: teamchannelTooltip({authorName, unknownUserDisplayName, channelId, channelMap, teamchannel}) },
                 { key: 't', truncateContent: false, content: m2dt(isValid(modified) ? modified : created) },
-                { key: 'c', truncateContent: true, content: <MessageContent body={body} type={type} filter={filter} /> }
+                { key: 'c', truncateContent: true, content: <ContentElement body={body} type={type} filter={filter} tooltip={true} /> }
             ],
         });
 

--- a/src/app/scripts/about/FindMsgIndex.tsx
+++ b/src/app/scripts/about/FindMsgIndex.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import * as du from "../dateUtils";
+import { currentLoginHintKey, IMyOwnState, ITeamsAuthComponentState, TeamsBaseComponentWithAuth } from "../msteams-react-base-component-with-auth";
+import { AppConfig } from '../../../config/AppConfig';
+import { Link } from "../ui";
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, TextField } from "@material-ui/core";
+import * as log from '../logger'
+
+/** about(index.html)用ロケール依存リソース定義 */
+export interface IFindMsgIndexTranslation {
+    /** マイクロソフトアカウントのユーザを入力してください */
+    UserPrincipalNameTitle: string;
+}
+
+/** about(index.html)用クラス固有ステータス */
+interface IFindMsgIndexState extends IMyOwnState {
+    /** クリックされたリンクの対象タブ名 */
+    selectedTab: string;
+    /** ダイアログから入力されたマイクロソフトアカウント名 */
+    dialogInput: string;
+}
+
+
+export class FindMsgIndex extends TeamsBaseComponentWithAuth {
+    protected async setAdditionalState(newstate: ITeamsAuthComponentState, context?: microsoftTeams.Context, inTeams?: boolean): Promise<void> {
+        if (context && inTeams? true : false) {
+            log.info(`★★★ setAdditionalState is called from componentDidMount; hosted in teams ★★★`);
+        }
+        const {hostedInTeams, teamsInfo} = newstate;
+        let {loginHint} = teamsInfo;
+        log.info(`★★★ Initial loginHint: [${loginHint}] ★★★`);
+        if (!hostedInTeams && loginHint === "") {
+            loginHint = sessionStorage.getItem(currentLoginHintKey) ?? "";
+            log.info(`★★★ Fetched saved loginHint from sessionStorage: [${loginHint}] ★★★`);
+            newstate.teamsInfo.loginHint = loginHint;
+        }
+    }
+
+    protected requireDatabase = false;
+    protected requireMicrosoftLogin = false;
+    protected isUsingStorage = false;
+    protected isTeamAndChannelComboIncluded = false;
+    protected GetPageTitle(): string {
+        return AppConfig.AppInfo.appName;
+    }
+    protected CreateMyState(): IMyOwnState {
+        const res: IFindMsgIndexState = {
+            initialized: true,
+            selectedTab: "",
+            dialogInput: "",
+        }
+        return res as IMyOwnState;
+    }
+    protected setMyState(): IMyOwnState {
+        return {initialized: true};
+    }
+    protected renderContentTop(): JSX.Element {
+        const config = AppConfig;
+        const imgsrc = `${config.AppInfo.logo}`;
+        return (
+            <header className="l-header">
+                <div className="logo">
+                    <img src={imgsrc} className="logo"/>
+                </div>
+                <div className="l-title">
+                    <h1>Welcome to <em>{config.AppInfo.appName} </em>!</h1>
+                </div>
+            </header>
+        );
+    }
+    protected renderContent(): JSX.Element {
+        const href = (tab: string, hint: string): string => {
+            return `https://${location.hostname}/${tab}/index.html?hint=${hint}&l=ja-jp`;
+        };
+
+        const handleClickOpen = (tab: string) => {
+            const {teamsInfo, me} = this.state;
+            let {selectedTab, dialogInput} = me as IFindMsgIndexState;
+            selectedTab = tab;
+            dialogInput = teamsInfo.loginHint;
+
+            log.info(`★★★ Link to tab [${selectedTab}] clicked ★★★`);
+            
+            const myOwn: IFindMsgIndexState = {
+                initialized: true,
+                selectedTab: selectedTab,
+                dialogInput: dialogInput,
+            };
+            this.setState({dialogOpen: true, me: myOwn});
+        };
+      
+        const handleClose = () => {
+            const myOwn: IFindMsgIndexState = {
+                initialized: true,
+                selectedTab: "",
+                dialogInput: "",
+            };
+            
+            this.setState({ dialogOpen: false, me: myOwn});
+        };
+
+        const handleOk = () => {
+            const {me} = this.state;
+            const {selectedTab, dialogInput} = me as IFindMsgIndexState;
+            
+
+            log.info(`★★★ Dialog input value: [${dialogInput}] ★★★`);
+
+            let address = "";
+            if (!((dialogInput?? "") === "")) {
+                address = href(selectedTab, dialogInput);
+
+                log.info(`★★★ Try navigating to [${address}] ★★★`);
+                location.href = address;
+            }
+        };
+
+        return (
+            <div>
+                <Dialog open={this.state.dialogOpen} onClose={handleClose} aria-labelledby="form-dialog-title">
+                <DialogContent>
+                    <DialogContentText>
+                        {this.state.translation.about.UserPrincipalNameTitle}
+                    </DialogContentText>
+                    <TextField
+                        required
+                        autoFocus
+                        margin="dense"
+                        id="name"
+                        type="email"
+                        fullWidth
+                        defaultValue={(this.state.me as IFindMsgIndexState).dialogInput}
+                        onChange={e => this.onDialogTextChange(e)}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleClose} color="primary">
+                    Cancel
+                    </Button>
+                    <Button onClick={handleOk} color="primary">
+                    OK
+                    </Button>
+                </DialogActions>
+                </Dialog>
+
+                <article className="l-article">
+                    <p>
+                        <Link onClick={() => handleClickOpen("FindMsgSearchTab")} disabled={this.state.loading}>Channel Message</Link>
+                    </p>
+                    <p>
+                        <Link onClick={() => handleClickOpen("FindMsgSearchChat")} disabled={this.state.loading}>Chat Message</Link>
+                    </p>
+                    <p>
+                        <Link onClick={() => handleClickOpen("FindMsgTopicsTab")} disabled={this.state.loading}>Topics List</Link>
+                    </p>
+                    <p>
+                        <Link onClick={() => handleClickOpen("FindMsgSearchSchedule")} disabled={this.state.loading}>Schedule</Link>
+                    </p>
+
+                </article>
+            </div>
+        );
+    }
+    protected renderContentBottom(): JSX.Element {
+        return (<div/>);
+    }
+    protected setStateCallBack(): void {
+        // 実装なし
+    }
+
+    protected onFilterChangedCallBack(): void {
+        // 実装なし
+    }
+    protected onSearchUserChangedCallBack(): void {
+        // 実装なし
+    }
+    protected onTeamOrChannelChangedCallBack(): void {
+        // 実装なし
+    }
+    protected onDateRangeChangedCallBack(): void {
+        // 実装なし
+    }
+    protected async startSync(): Promise<void> {
+        // 実装なし
+    }
+    protected async GetLastSync(): Promise<Date> {
+        return du.now();
+    }
+
+    onDialogTextChange(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>): void {
+        const data = e.target.value?? "";
+        log.info(`★★★ Dialog text changed: [${data}] ★★★`);
+
+        const {me} = this.state;
+        const {selectedTab} = me as IFindMsgIndexState;
+        const myOwn: IFindMsgIndexState = {
+            initialized: true,
+            selectedTab: selectedTab,
+            dialogInput: data,
+        };
+        this.setState({ me: myOwn });
+    }
+}

--- a/src/app/scripts/appInsights.ts
+++ b/src/app/scripts/appInsights.ts
@@ -1,4 +1,5 @@
 import { ApplicationInsights, IEventTelemetry, IExceptionTelemetry, IMetricTelemetry, ITraceTelemetry, Snippet } from '@microsoft/applicationinsights-web';
+import { AppConfig } from '../../config/AppConfig';
 
 // set this to enable/disable AI completely
 const useApplicationInsights = true;
@@ -11,7 +12,10 @@ function initAI(): ApplicationInsights | null {
     if (useApplicationInsights) {
         const config: Snippet = {
             config: {
-                instrumentationKey: '0b53b004-005f-46be-8fc1-63b98d9654e4',
+                // instrumentationKey: '0b53b004-005f-46be-8fc1-63b98d9654e4',
+                // Webapps(kacomslabo)
+                // instrumentationKey: '474f6161-5de0-419b-baa4-9d57b2abdb37',
+                instrumentationKey: AppConfig.AppInsight.instrumentationKey,
                 maxBatchInterval: 5000,
                 maxAjaxCallsPerView: -1,
                 disableDataLossAnalysis: false,

--- a/src/app/scripts/auth/auth.ts
+++ b/src/app/scripts/auth/auth.ts
@@ -36,6 +36,8 @@ const extraScopes = [
     "ChannelMessage.Read.All",  // Allows an app to read a channel's messages in Microsoft Teams, on behalf of the signed-in user.
     "Chat.Read",                // Read personal 1-to-1 and group chats
     "Calendars.Read",
+    "Files.Read",
+    "Files.ReadWrite",
 ];
 
 const consentScopes = [...requestScopesLogin, ...extraScopes];

--- a/src/app/scripts/auth/client.ts
+++ b/src/app/scripts/auth/client.ts
@@ -1,7 +1,10 @@
 import { PublicClientApplication } from "@azure/msal-browser";
+import { AppConfig } from "../../../config/AppConfig";
 
-const appId = "2e9f73d3-65f6-4ed6-8fbb-6ec025d9cde7"; // FindMsg
+// const appId = "2e9f73d3-65f6-4ed6-8fbb-6ec025d9cde7"; // FindMsg
 // const appId = "8fe75eb2-476b-43e1-8e36-a09cf42fcb42"; // FindMsg-NoConsentTest
+// const appId = "6f5036ec-ad6d-4b29-87cb-010b0702bce4"; // SeaChaSt
+const appId = AppConfig.AuthClient.AppId;
 
 export const client = new PublicClientApplication({
     auth: {

--- a/src/app/scripts/client.ts
+++ b/src/app/scripts/client.ts
@@ -9,7 +9,10 @@ export * from "./FindMsgTopicsTab/FindMsgTopicsTabRemove";
 export * from "./FindMsgSearchTab/FindMsgSearchTab";
 // Automatically added for the FindMsgSearchChat tab
 export * from "./FindMsgSearchChat/FindMsgSearchChat";
+// Automatically added for the FindMsgSearchSchedule tab
 export * from "./FindMsgSearchSchedule/FindMsgSearchSchedule";
+// Automatically added for the about page
+export * from "./about/FindMsgIndex";
 
 // only for (manual) debugging
 export { db } from "./db/Database";

--- a/src/app/scripts/db/Attendee/FindMsgAttendeeEntity.ts
+++ b/src/app/scripts/db/Attendee/FindMsgAttendeeEntity.ts
@@ -75,14 +75,14 @@ class AttendeeEntity<D extends IFindMsgAttendeeDb, T extends IFindMsgAttendee, A
                 res.forEach(rec => this.put(rec as T));
                 log.info(`registered [${res.length}] attendees for event [${parent.id}]`)
             });
-            this.storeLastSynced(du.now());
+            await this.storeLastSynced(du.now());
         }
         return res as T[];
     }
 
     protected async fetchApiDelta(arg: ISyncFunctionArg): Promise<T[]> {
         const res: Array<IFindMsgAttendee> = (arg.parent && (arg.parent as IFindMsgEvent).attendees) ?? [];
-        this.storeLastSynced(du.now());
+        await this.storeLastSynced(du.now());
         return res as T[];
     }
 

--- a/src/app/scripts/db/Database.ts
+++ b/src/app/scripts/db/Database.ts
@@ -7,7 +7,7 @@ import { IFindMsgTeamDb } from './IFindMsgTeamDb';
 import { IFindMsgChannelDb } from './IFindMsgChannelDb';
 import { IFindMsgChannelMessageDb } from './IFindMsgChannelMessageDb';
 import { IFindMsgUserDb } from './IFindMsgUserDb';
-import { info, traceAsync } from '../logger';
+import { info, traceAsync, warn } from '../logger';
 import { DbStatAggregator } from './DbStatAggregator';
 import { AI } from '../appInsights';
 import { collapseWhitespace, sanitize, stripHtml } from '../purify';
@@ -17,6 +17,12 @@ import { IFindMsgChatMessageDb } from './IFindMsgChatMessageDb';
 import { IFindMsgImageDb } from './IFindMsgImageDb';
 import { IFindMsgEventDb } from './Event/IFindMsgEventDb';
 import { IFindMsgAttendeeDb } from './Attendee/IFindMsgAttendeeDb';
+import IDBExportImport from 'indexeddb-export-import';
+import { Client } from '@microsoft/microsoft-graph-client';
+import { AppConfig } from '../../../config/AppConfig';
+import * as du from "../dateUtils";
+import { FileUtil } from '../fileUtil';
+
 
 /**
  * エンティティ(テーブル)名リソース用インターフェース
@@ -34,12 +40,16 @@ export interface IEntityNames {
     attendees: string;
 }
 
+export interface ITableLastSync {
+    id: string;
+    lastSync: number;
+}
+
 /**
  * Generate a compound index definition
  * @param args
  */
 const compound = (...args: string[]) => `[${args.join("+")}]`;
-
 
 /**
  * Generate an index specifier for dexie
@@ -118,6 +128,10 @@ const indexes = Object.freeze({
 
     attendees: Object.freeze({
         $eventId$id: compound(nameof<IFindMsgAttendeeDb>(a => a.eventId), nameof<IFindMsgAttendeeDb>(a => a.id)),
+    }),
+
+    lastsync: Object.freeze({
+        $id: nameof<ITableLastSync>(l => l.id),
     })
 });
 
@@ -140,6 +154,8 @@ class Database extends Dexie {
 
     /** Stores images attached to messages */
     images: Dexie.Table<IFindMsgImageDb, string>;
+
+    lastsync: Dexie.Table<ITableLastSync, string>;
 
     constructor(dbName: string) {
         super(dbName);
@@ -208,6 +224,10 @@ class Database extends Dexie {
             attendees: indexSpec(indexes.attendees),
         });
 
+        this.version(9).stores({
+            lastsync: indexSpec(indexes.lastsync),
+        });
+
         this.teams = this.table('teams');
         this.channels = this.table('channels');
         this.channelMessages = this.table('messages');
@@ -218,6 +238,10 @@ class Database extends Dexie {
         this.images = this.table('images');
         this.events = this.table('events');
         this.attendees = this.table('attendees');
+        this.lastsync = this.table('lastsync');
+
+        const lastUser = localStorage.getItem(this.lastUserKey());
+        this.userPrincipalName = lastUser?? "";
     }
 
     private static _onUpgrade(version: number) {
@@ -282,8 +306,210 @@ class Database extends Dexie {
         await this.d_resetChannelSynced(cid, true);
         await this.channelMessages.where(indexes.messages.$channelId$id).between([cid, Dexie.minKey], [cid, Dexie.maxKey]).delete();
     }
+
+    /**
+     * DBを使用する前に必ずログインしてください。
+     * @param client Graphクライアント
+     * @param userPrincipalName ログインヘルプ
+     */
+    async login(client: Client, userPrincipalName: string): Promise<boolean> {
+        info(`▼▼▼ Database.login START ▼▼▼`);
+        let res = false;
+
+        this.msGraphClient = client;
+        if (userPrincipalName != this.userPrincipalName) {
+            info(`★★★ Login user changed [${this.userPrincipalName}] => [${userPrincipalName}] ★★★`);
+            // アプリへの初回ログインまたはユーザが変わった場合は強制的にリロード
+            this.userPrincipalName = userPrincipalName;
+            localStorage.setItem(this.lastUserKey(), userPrincipalName);
+            res = await this.import();
+        } else {
+            // 同じユーザが使い続けている場合、現在のデバイス/ブラウザで最後にエクスポートまたはインポートした日付よりも
+            // エクスポートファイルの最終更新日時が新しければリロードする
+            // ※他のデバイス/ブラウザで同期・エクスポートした内容を取り込む想定
+            const lastExport = (): Date => {
+                const res = localStorage.getItem(this.lastExportKey());
+                return res? du.parseISO(res) : du.invalidDate();
+            };
+            const lastImport = (): Date => {
+                const res = localStorage.getItem(this.lastImportKey());
+                return res? du.parseISO(res) : du.invalidDate();
+            };
+
+            const latest = (lastExport() > lastImport())? lastExport() : lastImport();
+            
+            const file = await FileUtil.getFile(client, this.exportfileName(), this.exportfilePath());
+            if (file) {
+                const lastModified = file.lastModifiedDateTime? du.parseISO(file.lastModifiedDateTime) : du.invalidDate();
+
+                info(`★★★ lastExport:[${lastExport()}] lastImport:[${lastImport()}] lastModified:[${lastModified}] ★★★`);
+                if (lastModified > latest) {
+                    res = await this.import();
+                } else {
+                    res = true;
+                }
+            } else {
+                res = true;
+            }
+        }
+        info(`▲▲▲ Database.login END ▲▲▲`);
+        return res;
+    }
+
+    /**
+     * テーブルの最終同期日時を取得します
+     * @param id テーブルを識別するID
+     */
+    async getLastSync(id: string): Promise<Date> {
+        info(`▼▼▼ getLastSync START... ID: [${id}] ▼▼▼`);
+        let res = du.invalidDate();
+        const rec = await this.lastsync.get(id);
+        if (rec) {
+            res = du.numberToDate(rec.lastSync);
+        }
+        info(`▲▲▲ getLastSync END... ID: [${id}] result: [${res}] ▲▲▲`);
+        return res;
+    }
+
+    /**
+     * テーブルの最終同期日時を保存します
+     * @param id テーブルを識別するID
+     * @param date 同期実行した日時
+     * @param doExport trueを指定するとDBエクスポートを実施します(省略値はfalse)
+     */
+    async storeLastSync(id: string, date: Date, doExport?: boolean): Promise<void> {
+        info(`▼▼▼ storeLastSync START... ID: [${id}] date: [${date}] doExport: [${doExport}] ▼▼▼`);
+        await this.transaction("rw", this.lastsync, async() => {
+            const rec: ITableLastSync = {id: id, lastSync: du.dateToNumber(date)};
+            await this.lastsync.put(rec);
+        });
+        if (doExport?? false) {
+            // 最終同期日時は常にエクスポートファイルの最終更新日時より古くなるのでエクスポートの引数としては使用しない
+            // ※同一ユーザが使い続けているのに、タブを選択するたびにインポートが必要と判断されてしまうため
+            await this.export();
+        }
+        info(`▲▲▲ storeLastSync END... ID: [${id}] ▲▲▲`);
+    }
+
+    /**
+     * DBをクリアします
+     */
+    async clear(): Promise<boolean> {
+        info(`▼▼▼ clear START ▼▼▼`);
+        let res = false;
+        const idbDatabase = this.backendDB();
+        const clearDbCallback = async (error: any) => {
+            if (!error) res = true;
+        }
+        // Clear処理本体
+        IDBExportImport.clearDatabase(idbDatabase, clearDbCallback);
+        info(`▲▲▲ clear END ▲▲▲`);
+        return res
+    }
+
+    /**
+     * DBの全データをOneDriveにエクスポートします
+     * @param syncDatetime 最終エクスポート日時として保存する日時※省略時はnow()が保存されます
+     */
+    async export(syncDatetime?: Date): Promise<boolean> {
+        info(`▼▼▼ export START ▼▼▼`);
+        let res = false;
+
+        if (!this.msGraphClient) {
+            warn(`Database is not logged in!`);
+        } else {
+            const idbDatabase = this.backendDB();
+            const exportCallback = async (error: any, jsonString: string) => {
+                if (error) {
+                    warn(`Error in exportToJsonString: [${error}]`);
+                } else {
+                    // info(`DB exported: [${jsonString}]`);
+                    if (this.msGraphClient? await FileUtil.writeFile(this.msGraphClient, this.exportfileName(), jsonString, this.exportfilePath(), true) : false) {
+                        res = true;
+                        const lastExport = syncDatetime?? du.now();
+                        localStorage.setItem(this.lastExportKey(), du.formatISO(lastExport));
+                    }
+                }
+            }
+            // Export処理本体    
+            IDBExportImport.exportToJsonString(idbDatabase, exportCallback);
+        }
+
+        info(`▲▲▲ export END ▲▲▲`);
+
+        return res;
+    }
+
+    /**
+     * DBのデータをOneDriveからインポートします
+     */
+    async import(): Promise<boolean> {
+        info(`▼▼▼ import START ▼▼▼`);
+        let res = false;
+
+        const idbDatabase = this.backendDB();
+        const importCallback = (error: any) => {
+            if (error) {
+                error(`Error in importFromJsonString: [${error}]`);
+            } else {
+                res = true;
+                localStorage.setItem(this.lastImportKey(), du.formatISO(du.now()));
+                info(`DB import successfully completed!`);
+            }
+        }
+        // インポートを実施する前に、有無を言わさずDBをクリアする
+        if (this.clear()) {
+            if (!this.msGraphClient) {
+                warn(`Database is not logged in!`);
+            } else {
+                // インポートすべきファイルがあるかどうかを確認
+                const file = await FileUtil.getFile(this.msGraphClient, this.exportfileName(), this.exportfilePath(), true);
+                if (file) {
+                    const jsonString = await FileUtil.readFile(this.msGraphClient, this.exportfileName(), this.exportfilePath());
+                    // info(`Data importing into DB: [${jsonString}]`);
+                    if (jsonString) {
+                        // Import処理本体
+                        IDBExportImport.importFromJsonString(idbDatabase, jsonString, importCallback);
+                    } else {
+                        warn(`DB import failed due to either file not found or read failure`);
+                    }
+                } else {
+                    res = true;
+                    info(`Exported file does not exist; import command ignored.`);
+                }
+            }
+        }
+    info(`▲▲▲ import END ▲▲▲`);
+
+        return res;
+    }
+
+ 
+    // セキュリティ関連プロパティ
+    private msGraphClient: Client | undefined = undefined;
+    private userPrincipalName = "";
+    // Export/Import用のワークプロパティ
+    private lastUserKey(): string { return `${this.name}-lastUser`;}
+    private lastExportKey(): string { return `${this.name}-${this.userPrincipalName}-lastExported`; }
+    private lastImportKey(): string { return `${this.name}-${this.userPrincipalName}-lastImported`; }
+    private accountDomain(): string {
+        let res = "";
+        if (this.userPrincipalName.indexOf("@") > 0) {
+            res = this.userPrincipalName.split("@")[1];
+        }
+        return res;
+    }
+    private accountName(): string {
+        let res = "";
+        if (this.userPrincipalName.indexOf("@") > 0) {
+            res = this.userPrincipalName.split("@")[0];
+        }
+        return res;
+    }
+    private exportfileName(): string { return "db.dat";}
+    private exportfilePath(): string { return `AppData/${AppConfig.AppInfo.name}/${this.accountDomain()}/${this.accountName()}`;}
+    
 }
 
-
-export const db = new Database("FindMsg-database");
+export const db = new Database(`${AppConfig.AppInfo.name}-database`);
 export const idx = indexes;

--- a/src/app/scripts/db/IFindMsgImageDb.ts
+++ b/src/app/scripts/db/IFindMsgImageDb.ts
@@ -13,4 +13,7 @@ export interface IFindMsgImageDb {
 
     /** Image data */
     data: Blob;
+
+    /** Blobから変換したBase64文字列 */
+    dataUrl: string | null;
 }

--- a/src/app/scripts/db/db-accessor-class-base.ts
+++ b/src/app/scripts/db/db-accessor-class-base.ts
@@ -155,8 +155,9 @@ export abstract class DbAccessorBaseComponent<D extends IDbEntityBase, T extends
     protected abstract syncSubentity(arg: ISyncFunctionArg, parents: T[]): Promise<boolean>;
 
     /** このエンティティの最終同期日時を取得 */
-    getLastSynced(): Date {
-        const res = du.parseISO(localStorage.getItem(this.lastSyncedKey) ?? "");
+    async getLastSynced(): Promise<Date> {
+        // const res = du.parseISO(localStorage.getItem(this.lastSyncedKey) ?? "");
+        const res = await db.getLastSync(this.lastSyncedKey);
         return res
     }
     
@@ -164,8 +165,9 @@ export abstract class DbAccessorBaseComponent<D extends IDbEntityBase, T extends
      * このエンティティを同期した日時を保存
      * @param m タイムスタンプ
      */
-    storeLastSynced(m: Date): void {
-        localStorage.setItem(this.lastSyncedKey, du.formatISO(m));
+    async storeLastSynced(m: Date, doExport?: boolean): Promise<void> {
+        // localStorage.setItem(this.lastSyncedKey, du.formatISO(m));
+        await db.storeLastSync(this.lastSyncedKey, m, doExport);
     }
 
     async get(id: string, subentity?: boolean): Promise<T | null> {
@@ -231,7 +233,7 @@ export abstract class DbAccessorBaseComponent<D extends IDbEntityBase, T extends
         log.info(`▼▼▼ ` + this.tableName + `.sync START ▼▼▼`);
         let res = false;
         
-        const lastSync = this.getLastSynced();
+        const lastSync = await this.getLastSynced();
         const neverSynced = !du.isValid(lastSync);
 
         // can only get messages in the last 8 months via delta endpoint, but add margin of error

--- a/src/app/scripts/fileUtil.ts
+++ b/src/app/scripts/fileUtil.ts
@@ -1,0 +1,332 @@
+import { Client } from "@microsoft/microsoft-graph-client";
+import { DriveItem, UploadSession } from "@microsoft/microsoft-graph-types-beta";
+import { getAllPages } from "./graph/getAllPages";
+import * as log from './logger';
+
+export interface DriveItemExtended extends DriveItem {
+    downloadUrl : string | null;
+}
+
+const reformPathString = (path?: string | null | undefined) => {
+    return path? (path.startsWith("root/"))? path.substr(5) : path : "root"
+}
+
+/** ファイル操作ユーティリティクラス */
+class Util {
+
+    /**
+     * 指定フォルダにあるドライブ項目(フォルダ/ファイル)をすべて取得します。
+     * @param client MicrosoftGraphクライアント
+     * @param parentPath 走査したいフォルダまでのパス(パス区切り文字は「/」)※パスを省略するとroot直下を調べます。またパスを指定する際はrootは省略可能です。
+     * @param createFolderIfNotExist trueを指定するとパス内に存在しないフォルダがある場合にフォルダを作成します。
+     */
+    public async getItems(client: Client, parentPath?: string | null | undefined, createFolderIfNotExist?: boolean): Promise<DriveItem[]> {
+        // 目的のフォルダをrootからのパスで指定するが、rootは省略可能
+        const parent = reformPathString(parentPath);
+        log.info(`▼▼▼ getItems START parentPath: [${parent}] createIfNotExist: [${createFolderIfNotExist?? false}] ▼▼▼`);
+        const res: DriveItem[] = [];
+        if (parent === "root") {
+            const address = `me/drive/root/children`;
+            log.info(`★★★ requesting api(get): [${address}] ★★★`);
+            const api = await client.api(address).get();
+            const fetched = await getAllPages<DriveItem>(client, api);
+            fetched.forEach(rec => {res.push(rec)});
+            log.info(`★★★ Found [${res.length}] items in root folder ★★★`);
+        } else {
+            const paths = parent.split('/');
+            let folder: DriveItem | null = null;
+            for (let i = 0; i < paths.length; i++ ) {
+                const found = await this.findFolder(client, paths[i], folder, createFolderIfNotExist);
+                if (!found) {
+                    folder = null;
+                    break;
+                } else {
+                    folder = found;
+                }
+            }
+            if (folder && folder.id) {
+                const address = `/me/drive/items/${folder.id}/children`;
+                log.info(`★★★ requesting api(get): [${address}] ★★★`);
+                const api = await client.api(address).get();
+                const fetched = await getAllPages<DriveItem>(client, api);
+                fetched.forEach(rec => {res.push(rec)});
+                log.info(`★★★ Found [${res.length}] items in the folder [${folder.name}] ★★★`);
+            }
+        }
+        log.info(`▲▲▲ getItems END parentPath: [${parent}] createIfNotExist: [${createFolderIfNotExist?? false}] ▲▲▲`);
+        return res;
+    }
+
+    /**
+     * 指定フォルダを取得します。
+     * @param client MicrosoftGraphクライアント
+     * @param folderPath 取得したいフォルダのパス(パス区切り文字は「/」)※パスを省略するとrootを取得します。またパスを指定する際はrootは省略可能です。
+     * @param createFolderIfNotExist trueを指定するとパス内に存在しないフォルダがある場合にフォルダを作成します。
+     */
+    public async getFolder(client: Client, folderPath: string, createFolderIfNotExist?: boolean): Promise<DriveItem | null> {
+        log.info(`▼▼▼ getFolder START folderPath: [${folderPath}] createIfNotExist: [${createFolderIfNotExist?? false}] ▼▼▼`);
+        let res: DriveItem | null = null;
+        const path = reformPathString(folderPath);
+
+        if (path.indexOf("/") < 0) {
+            if (path === "root") {
+                const address = `/me/drive/root`;
+                log.info(`★★★ requesting api(get): [${address}] ★★★`);
+                res = await client.api(address).get();
+                log.info(`★★★ Found the root folder ID: [${res?.id}] ★★★`);
+            } else {
+                // root直下のフォルダの場合
+                res = await this.findFolder(client, path, null, createFolderIfNotExist);
+            }
+        } else {
+            // 親階層のフォルダを特定した上で対象のフォルダを取得する
+            const parent = path.substr(0, path.lastIndexOf("/"));
+            const find = path.substr(parent.length + 1);
+            log.info(`Calling getFolder recursive; parent: [${parent}] find: [${find}]`);
+            const parentFolder = await this.getFolder(client, parent, createFolderIfNotExist);
+            if (parentFolder) {
+                res = await this.findFolder(client, find, parentFolder, createFolderIfNotExist);
+            }
+        }
+
+        log.info(`▲▲▲ getFolder END folderPath: [${folderPath}] createIfNotExist: [${createFolderIfNotExist?? false}] resultName: [${res? res.name : "(not found)"}] resultId: [${res? res.id : "(not found)"}] ▲▲▲`);
+        return res;
+    }
+
+    /**
+     * 指定ファイルを取得します。ファイルが見つからない場合はnullを返却します。
+     * @param client MicrosoftGraphクライアント
+     * @param find ファイル名
+     * @param parentPath フォルダのパス(パス区切り文字は「/」)※パスを省略するとrootを取得します。またパスを指定する際はrootは省略可能です。
+     * @param createFolderIfNotExist trueを指定するとパス内に存在しないフォルダがある場合にフォルダを作成します。
+     */
+    public async getFile(client: Client, find: string, parentPath?: string | null | undefined, createFolderIfNotExist?: boolean): Promise<DriveItem | null> {
+        log.info(`▼▼▼ getFile START parentPath: [${parentPath}] createIfNotExist: [${createFolderIfNotExist?? false}] ▼▼▼`);
+        let res: DriveItem | null = null;
+
+        const parent = reformPathString(parentPath);
+        const items = await this.getItems(client, parent, createFolderIfNotExist);
+        log.info(`★★★ [${items.length}] items found in [${parent}] ★★★`);
+        for (let i = 0; i < items.length; i++) {
+            log.info(`★★★ file [${i}] in [${parent}]: name=[${items[i].name}] id=[${items[i].id}] ★★★`);
+            if (items[i].name === find) {
+                if (items[i].file) {
+                    res = items[i];
+                    log.info(`★★★ Target found. name=[${res.name}] id=[${res.id}] ★★★`);
+                    break;
+                }
+            }
+        }
+
+        log.info(`▲▲▲ getFile END parentPath: [${parentPath}] createIfNotExist: [${createFolderIfNotExist?? false}] ▲▲▲`);
+        return res;
+    }
+
+    /**
+     * 指定ファイルに文字列データを書き込みます。
+     * @param client MicrosoftGraphクライアント
+     * @param fileName ファイル名
+     * @param content ファイルに書き込むファイル
+     * @param parentPath フォルダのパス(パス区切り文字は「/」)※パスを省略するとrootを取得します。またパスを指定する際はrootは省略可能です。★存在しないフォルダは作成されます。
+     * @param overwrite trueを指定すると指定ファイル名がすでに存在する場合に上書きします。
+     */
+    public async writeFile(client: Client, fileName: string, content: string, parentPath?: string | null | undefined, overwrite?: boolean): Promise<boolean> {
+        log.info(`▼▼▼ writeFile START parentPath: [${parentPath}] fileName: [${fileName}] overwrite:[${overwrite}] ▼▼▼`);
+        let res = false;
+
+        let ow = overwrite?? false;
+
+        try {
+            const parent = reformPathString(parentPath);
+            let file = await this.getFile(client, fileName, parentPath, true);
+            if (!file) {
+                // ファイルが存在しない場合は先にファイルの「枠」だけ作成
+                if (parent === "root") {
+                    const address = `/me/drive/root:/${fileName}/content`;
+                    log.info(`★★★ requesting api(put): [${address}] ★★★`);
+                    file = await client.api(address).put("");
+                    if (file) {
+                        ow = true;
+                       log.info(`★★★ File [${fileName}] created in the root folder... New ID: [${file.id}] ★★★`);
+                    } else {
+                        log.warn(`★★★ File [${fileName}] failed to create in the root folder ★★★`);
+                    }
+                } else {
+                    const folder = await this.getFolder(client, parent, true);
+                    if (folder && folder.id) {
+                        const address = `/me/drive/items/${folder.id}:/${fileName}:/content`;
+                        log.info(`★★★ requesting api(put): [${address}] ★★★`);
+                        file = await client.api(address).put("");
+                        if (file) {
+                            ow = true;
+                            log.info(`★★★ File [${fileName}] created in the folder [${folder.name}]... New ID: [${file.id}] ★★★`);
+                        } else {
+                            log.warn(`★★★ File [${fileName}] failed to create in the folder [${folder.name}] ★★★`);
+                        }
+                    }
+                }
+            }
+
+            let item: DriveItem | null = null;
+            if (file && file.id) {
+                if (ow) {
+                    const buf = Buffer.from(content);
+                    const wholesize = buf.length;
+                    if (wholesize < (1024 * 1024 * 4)) {
+                        // 4MB未満のファイルは直接アップロード
+                        const address = `/me/drive/items/${file.id}/content`;
+                        log.info(`★★★ requesting api(put): [${address}] ★★★`);
+                        item = await client.api(address).put(content);
+                        if (item) {
+                            res = true;
+                            log.info(`★★★ File [${item.name}] ID: [${item.id}] overwritten ★★★`);    
+                        } else {
+                            log.warn(`★★★ File [${fileName}] failed to write ★★★`);
+                        }
+                    } else {
+                        // 4MB以上のファイルはアップロードセッションで分割してアップロード
+                        const address1 = `/me/drive/items/${file.id}/createUploadSession`;
+                        log.info(`★★★ requesting api(post): [${address1}] ★★★`);
+                        const session: UploadSession | null | undefined = await client.api(address1).post("");
+                        if (session && session.uploadUrl) {
+                            const url = session.uploadUrl;
+                            log.info(`Upload URL: [${url}] in response: [${JSON.stringify(session)}]`);
+
+                            const max = (320 * 1024) * 10;
+                            let start = 0;
+                            while (start < wholesize) {
+                                const rest = wholesize - start;
+                                let len = max;
+                                if (rest < max) {
+                                    len = rest;
+                                }
+                                const end = start + len;
+                                const send = buf.slice(start, end);
+                                log.info(`★★★ Sending ${len} (actual ${send.length}) bytes of ${start}-${end - 1}/${wholesize} ★★★ `);
+                                const req = new XMLHttpRequest();
+                                req.open("PUT", url, false);
+                                // req.setRequestHeader("Content-Length", `${len}`);
+                                req.setRequestHeader("Content-Range", `bytes ${start}-${end - 1}/${wholesize}`);
+                                req.send(send);
+                                log.info(`★★★  Responce: ${JSON.stringify(req.response)} ★★★ `);
+                                start = end;
+                            }
+                            res = true;
+                        }
+                    }
+                } else {
+                    log.warn(`★★★ File [${fileName}] exists and was not overwritten ★★★`);
+                }
+            }
+        } catch (err) {
+            log.error(`Error in writing file [${fileName}]: [${JSON.stringify(err)}]`);
+        }
+
+        log.info(`▲▲▲ writeFile END parentPath: [${parentPath}] fileName: [${fileName}] ▲▲▲`);
+
+        return res;
+    }
+
+    /**
+     * 指定テキストファイルを読み込みます。ファイルが見つからない場合はnullを返却します。
+     * @param client MicrosoftGraphクライアント
+     * @param fileName ファイル名
+     * @param parentPath フォルダのパス(パス区切り文字は「/」)※パスを省略するとrootを取得します。またパスを指定する際はrootは省略可能です。★存在しないフォルダを作成しません。
+     */
+    public async readFile(client: Client, fileName: string, parentPath?: string | null | undefined): Promise<string | null> {
+        log.info(`▼▼▼ readFile START parentPath: [${parentPath}] fileName: [${fileName}] ▼▼▼`);
+
+        let res: string | null = null;
+        const file = await this.getFile(client, fileName, parentPath);
+        if (file) {
+            const fileEx: DriveItemExtended =JSON.parse(JSON.stringify(file).replace("@microsoft.graph.downloadUrl", "downloadUrl"));
+            if (fileEx.downloadUrl) {
+                log.info(`★★★ readFile file found id: [${fileEx.id}] downloadUrl: [${fileEx.downloadUrl}] ★★★`);
+                const downloadUrl = fileEx.downloadUrl;
+                log.info(`★★★ readFile file downloadUrl: [${downloadUrl}] ★★★`);
+    
+                const request = new XMLHttpRequest();
+                request.open("GET", downloadUrl, false);
+                request.send();
+                res = request.response;
+                log.info(`★★★ File [${fileName}] found and fetched... ID: [${file.id}] ★★★`);
+            }
+        } else {
+            log.info(`★★★ File [${fileName}] not found ★★★`);
+        }
+        log.info(`▲▲▲ readFile END parentPath: [${parentPath}] fileName: [${fileName}] ▲▲▲`);
+        return res;
+    }
+
+    /**
+     * 親フォルダ内から、指定した名前のフォルダを取得します。
+     * @param client MicrosoftGraphクライアント
+     * @param find フォルダ名
+     * @param parent 親フォルダまでのパス(パス区切り文字は「/」)※パスを省略するとrootを取得します。またパスを指定する際はrootは省略可能です。
+     * @param createFolderIfNotExist trueを指定するとパス内に存在しないフォルダがある場合にフォルダを作成します。
+     */
+    private async findFolder(client: Client, find: string, parent?: DriveItem | null | undefined, createFolderIfNotExist?: boolean): Promise<DriveItem | null> {
+        log.info(`▼▼▼ findFolder START parent: [${parent? parent.name : "root"}] find: [${find}] createFolderIfNotExist: [${createFolderIfNotExist}] ▼▼▼`);
+        let res: DriveItem | null = null;
+
+        const children: DriveItem[] = [];
+        let parentId: string | null = null;
+        if (parent) {
+            if (parent.id) {
+                parentId = parent.id;
+                const address = `/me/drive/items/${parent.id}/children`;
+                log.info(`★★★ requesting api(get): [${address}] ★★★`);
+                const api = await client.api(address).get()
+                const fetched = await getAllPages<DriveItem>(client, api);
+                fetched.forEach(rec => {children.push(rec)});
+                log.info(`★★★ Found [${children.length}] items in the folder ID: [${parent.id}] ★★★`);
+            }
+        } else {
+            const address = `/me/drive/root/children`;
+            log.info(`★★★ requesting api(get): [${address}] ★★★`);
+            const api = await client.api(address).get();
+            const fetched = await getAllPages<DriveItem>(client, api);
+            fetched.forEach(rec => {children.push(rec)});
+            log.info(`★★★ Found [${children.length}] items in the root folder ★★★`);
+        }
+
+        for (let i = 0; i < children.length; i++) {
+            const item = children[i];
+            if (item.folder && item.name === find) {
+                res = item;
+                log.info(`★★★ Folder [${res.name}] found... ID: [${res.id}] ★★★`);
+                break;
+            }
+        }
+
+        if (!res && (createFolderIfNotExist?? false)) {
+            const driveItem = {
+                name: find,
+                folder: { },
+            };
+            if (parent) {
+                const address = `/me/drive/items/${parentId}/children`;
+                log.info(`★★★ requesting api(post): [${address}] ★★★`);
+                res = await client.api(address).post(driveItem);
+                if (res) {
+                    log.info(`★★★ Folder [${res.name}] created... ID: [${res.id}] ★★★`);
+                }
+            } else {
+                const address = `/me/drive/root/children`;
+                log.info(`★★★ requesting api(post): [${address}] ★★★`);
+                res = await client.api(address).post(driveItem);
+                if (res) {
+                    log.info(`★★★ Folder [${res.name}] created... ID: [${res.id}] ★★★`);
+                }
+            }
+        }
+        log.info(`▲▲▲ findFolder END parent: [${parent? parent.name : "root"}] find: [${find}] createFolderIfNotExist: [${createFolderIfNotExist}] ▲▲▲`);
+
+        return res;
+    }
+}
+
+/**
+ * OneDrive上のフォルダやファイルを操作するユーティリティです。
+ */
+export const FileUtil = new Util();

--- a/src/app/scripts/graphImage.ts
+++ b/src/app/scripts/graphImage.ts
@@ -1,8 +1,38 @@
 import { db } from './db/Database';
+import * as log from './logger';
 
 // this must NOT be an arrow function so that [this] points to the element
 const revoke = function (this: GlobalEventHandlers): void { URL.revokeObjectURL((this as HTMLImageElement).src) };
 
+const b64toBlob = (b64Data: string, sliceSize=512) => {
+    log.info(`▼▼▼ b64toBlob START b64Data: [${b64Data}] ▼▼▼`);
+    let contentType = "";
+    const endpos = b64Data.indexOf(";");
+    if (endpos > 0) {
+        const b64header = b64Data.substring(0, endpos);
+        const start = b64header.indexOf(":") + 1;
+        contentType = b64header.substring(start);
+        log.info(`header [${b64header} start: [${start}] ==> contentType: [${contentType}]`);
+    }
+    const byteCharacters = atob(b64Data.replace(/^.*,/, ""));
+    const byteArrays: BlobPart[] = [];
+  
+    for (let offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+      const slice = byteCharacters.slice(offset, offset + sliceSize);
+  
+      const byteNumbers = new Array(slice.length);
+      for (let i = 0; i < slice.length; i++) {
+        byteNumbers[i] = slice.charCodeAt(i);
+      }
+  
+      const byteArray = new Uint8Array(byteNumbers);
+      byteArrays.push(byteArray);
+    }
+  
+    const blob = new Blob(byteArrays, {type: contentType});
+    log.info(`▲▲▲ b64toBlob END ▲▲▲`);
+    return blob;
+  }
 
 /**
  * Backing logic for custom html element <graph-image>
@@ -30,12 +60,16 @@ export class GraphImage extends HTMLElement {
         const img = await db.images.get(src)
         if (!img) return;
 
+        const data = img.dataUrl? b64toBlob(img.dataUrl?? "") : null;
+        if (!data) return;
+
         this.removeContents();
 
         const el = document.createElement("img");
         el.onload = revoke;
         el.onerror = this.imageError;
-        el.src = URL.createObjectURL(img.data);
+        // el.src = URL.createObjectURL(img.data);
+        el.src = URL.createObjectURL(data);
 
         this.append(el);
     }

--- a/src/app/scripts/i18n/IMessageTranslation.ts
+++ b/src/app/scripts/i18n/IMessageTranslation.ts
@@ -1,6 +1,6 @@
 import { ISyncWidgetTranslation } from "../SyncWidget";
 import { IMessageTableTranslation } from "../FindMsgTopicsTab/MessageTable";
-import { ITopicsTabTranslation, ISearchTabTranslation, IFindMsgTopicsTabConfigTranslation, IChatSearchTabTranslation } from "../client";
+import { ITopicsTabTranslation, ISearchTabTranslation, IFindMsgTopicsTabConfigTranslation, IChatSearchTabTranslation, IFindMsgIndexTranslation } from "../client";
 import { ISyncProgressTranslation } from "../db";
 import { IAuthMessages } from "../auth/IAuthMessages";
 import { ICommonErrorMessage } from "./ICommonErrorMessage";
@@ -39,5 +39,6 @@ export interface IMessageTranslation {
     chatSearch: IChatSearchTabTranslation;
     schedule: IFindMsgScheduleTranslation;
     eventTable: IEventTableTranslation;
+    about: IFindMsgIndexTranslation;
 
 }

--- a/src/app/scripts/i18n/messages.ts
+++ b/src/app/scripts/i18n/messages.ts
@@ -8,7 +8,7 @@ const availableLocales: { [key: string]: IMessageTranslation | undefined } = Obj
 availableLocales.en = messages_en;
 availableLocales.ja = messages_ja;
 
-const fallbackLocale = messages_en;
+const fallbackLocale = messages_ja;
 
 export const get = (locale?: string | null): IMessageTranslation => {
     if (locale) {

--- a/src/app/scripts/i18n/messages_en.ts
+++ b/src/app/scripts/i18n/messages_en.ts
@@ -179,5 +179,9 @@ export const messages: IMessageTranslation = {
         allday: "(all day)",
         notitle: "(no title)",
         noattendee: "(none)",
-        },
+    },
+
+    about: {
+            UserPrincipalNameTitle: "Please input your Microsoft Account",
+    },
 }

--- a/src/app/scripts/i18n/messages_ja.ts
+++ b/src/app/scripts/i18n/messages_ja.ts
@@ -179,5 +179,9 @@ export const messages: IMessageTranslation = {
         allday: "(終日)",
         notitle: "(件名なし)",
         noattendee: "(なし)",
-        },
+    },
+    
+    about: {
+        UserPrincipalNameTitle: "マイクロソフトアカウントを入力してください"
+    },
 }

--- a/src/app/web/index.html
+++ b/src/app/web/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Message Finder</title>
+  <title>Loading...</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- inject:css -->
   <!-- endinject -->
@@ -12,31 +12,14 @@
   <!-- {{COMMIT_NUMBER}} -->
 </head>
 
-<body>
-  <header class="l-header">
-    <div class="logo">
-      <img src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/product-fluent/svg/teams_48x1.svg"
-        class="logo">
-    </div>
-    <div class="l-title">
-      <h1>Welcome to <em>Message Finder</em>!</h1>
-    </div>
-  </header>
-  <article class="l-article">
-    <p>
-      <a href="https://cuehirai.github.io/FindMsgSearchTab/index.html?l=ja-jp">Channel Message</a>
-    </p>
-    <p>
-      <a href="https://cuehirai.github.io/FindMsgSearchChat/index.html?l=ja-jp">Chat Message</a>
-    </p>
-    <p>
-      <a href="https://cuehirai.github.io/FindMsgTopicsTab/index.html?l=ja-jp">Topics List</a>
-    </p>
-    <p>
-      <a href="https://cuehirai.github.io/FindMsgSearchSchedule/index.html?l=ja-jp">Schedule</a>
-    </p>
-
-  </article>
+<body class="minWidth">
+  <div id='app'>
+    Loading...
+  </div>
+  <script src="/scripts/client.js"></script>
+  <script type='text/javascript'>
+    FindMsg.FindMsgIndex.render(document.getElementById('app'), {});
+  </script>
 </body>
 
 </html>

--- a/src/config/AppConfig.ts
+++ b/src/config/AppConfig.ts
@@ -1,0 +1,35 @@
+export interface IAppConfig {
+    AppInfo: {
+        name: string;
+        appName: string;
+        logo: string;
+        host: string;
+    };
+    AuthClient: {
+        AppId: string;
+    };
+    AppInsight: {
+        instrumentationKey: string;
+    };
+}
+
+const config = (): IAppConfig => {
+    const res: IAppConfig = {
+        AppInfo: {
+            name: process.env.PACKAGE_NAME ?? "FindMsg",
+            appName: process.env.APP_NAME ?? "Message Finder",
+            logo: process.env.LOGO ?? "https://static2.sharepointonline.com/files/fabric/assets/brand-icons/product-fluent/svg/teams_48x1.svg",
+            host: process.env.HOSTNAME ?? "",
+        },
+        AuthClient: {
+            AppId: process.env.APPLICATION_ID ?? "",
+        },
+        AppInsight: {
+            instrumentationKey: process.env.APPINSIGHTS_INSTRUMENTATIONKEY ?? "",
+        },
+    };
+
+    return res;
+}
+
+export const AppConfig = config();

--- a/tsconfig-client.json
+++ b/tsconfig-client.json
@@ -4,6 +4,7 @@
         "target": "ES2017",
         "lib": ["DOM", "ES2017", "ES2019.Array"],
         "moduleResolution": "node",
+        "resolveJsonModule": true,
         "experimentalDecorators": true,
         "esModuleInterop": true,
         "removeComments": true,


### PR DESCRIPTION
1. データベース名変更

　「FindMsg-database」 ⇒「{アプリ名}-database」に変更。

　これにより、同じサイトにアプリ名だけ変更した別アプリが
　同じデータベースを参照することを防止。

2. データベースのエクスポート/インポート機能追加

　この機能の目的は；

　(1) 別のデバイス(またはブラウザ)でアプリを使っても、
　　　常に同じデータを使用できるようにする
　(2) 一つのデバイスで複数ユーザがアプリを使用する場合
　　　であっても、他人のデータは参照できないようにする

　これに伴い以下の機能を追加

　(1) ファイルユーティリティ(fileUtil.ts)を追加

　　　現在のユーザのOneDriveファイルへのアクセスをサポート
　　　※他のユーザから見ることができないので安全にデータベース
　　　　のエクスポートファイルを管理することができる

　(2) データベースへのログイン
　　　※アプリはデータベースを使用する前にデータベース
　　　　へのログインを行うこと！

　　- 初回アプリ起動時及び前回ユーザと異なるユーザがアプリを
　　　開いた場合はデータベースをクリアし、エクスポートされた
　　　ファイルが存在すればそれをインポートする

　　- 前回と同じユーザがアプリを開いた場合は、
　　　最終エクスポート日時または最終インポート日時のいずれか
　　　新しいほうの日付よりもエクスポートファイルが新しい場合
　　　エクスポートファイルをインポートする
　　　エクスポートファイルの方が古い場合は何もしない

　(3) イメージテーブルにbase64のフィールドを追加
　　　※Blobでデータベースに保存していたが、エクスポートする
　　　　ためには文字列に変換する必要があった

　(4) 各テーブルの最終同期日時の保存先ををデータベーステーブル
　　　に変更

3. トピック一覧、スケジュール検索の本文にTooltipを実装