### PR TITLE
エクスポート機能拡張

### DIFF
--- a/src/app/scripts/FindMsgSearchSchedule/FindMsgSearchSchedule.tsx
+++ b/src/app/scripts/FindMsgSearchSchedule/FindMsgSearchSchedule.tsx
@@ -11,6 +11,7 @@ import { ISyncFunctionArg, OrderByDirection } from "../db/db-accessor-class-base
 import { IFindMsgEvent } from "../db/Event/IFindMsgEvent";
 import { AppConfig } from "../../../config/AppConfig";
 import * as du from "../dateUtils";
+import { db } from "../db/Database";
 
 /** スケジュール検索用ロケール依存リソース定義 */
 export interface IFindMsgScheduleTranslation {
@@ -58,7 +59,8 @@ interface ISavedState {
  * スケジュール検索コンポーネント
  */
 export class FindMsgSearchSchedule extends TeamsBaseComponentWithAuth {
-    protected exportOptionAvailable = true;
+    protected exportTargetTables = [db.events, db.attendees, db.lastsync];
+    protected exportOptionAvailable = false;
     protected isFixedPageSize = false;
     protected showInformation = true;
     protected async setAdditionalState(newstate: ITeamsAuthComponentState, context?: microsoftTeams.Context, inTeams?: boolean): Promise<void> {

--- a/src/app/scripts/FindMsgSearchTab/FindMsgSearchTab.tsx
+++ b/src/app/scripts/FindMsgSearchTab/FindMsgSearchTab.tsx
@@ -23,6 +23,7 @@ import { getTopLevelMessagesLastSynced } from "../db/Sync";
 import { ICommonMessage } from "../i18n/ICommonMessage";
 import { DatabaseLogin, ExportImportComponents, getChannelMap, getInformation, IChannelInfo, IExportImportArgs, IExportImportState } from "../ui-jsx";
 import { db } from "../db/Database";
+import { currentLoginHintKey } from "../msteams-react-base-component-with-auth";
 
 
 export declare type MyTeam = IFindMsgTeam & { channels: IFindMsgChannel[] };
@@ -367,6 +368,7 @@ export class FindMsgSearchTab extends TeamsBaseComponent<never, IFindMsgSearchTa
             groupId = teamOptions[teamIdx].key;
             channelId = channelOptions[teamIdx][channelIdx].key;
         }
+        sessionStorage.setItem(currentLoginHintKey, loginHint);
 
         this.setState({
             teamsInfo: {
@@ -487,11 +489,12 @@ export class FindMsgSearchTab extends TeamsBaseComponent<never, IFindMsgSearchTa
         const exportImportCompArg: IExportImportArgs = {
             lastSyncedKey: lastSyncedKey,
             exportCallback: async (newState: IExportImportState) => {this.setState({exportImportState: newState});},
-            importCallback: async (newState: IExportImportState, lastSynced: Date) => {this.setState({lastSynced: lastSynced, exportImportState: newState})},
+            importCallback: async (newState: IExportImportState, lastSynced: Date) => {this.setState({lastSynced: lastSynced, exportImportState: newState}, this.initInfo)},
             otherCallback: (newState: IExportImportState) => {this.setState({exportImportState: newState});},
             state: {...this.state.exportImportState},
             translate: this.state.t,
             exportOptionAvailable: true,
+            exportTargetTables: [db.teams, db.channels, db.channelMessages, db.images, db.users, db.lastsync],
         }
 
         // const dbCopy: ComponentEventHandler<ButtonProps> = async() => {

--- a/src/app/scripts/FindMsgTopicsTab/FindMsgTopicsTab.tsx
+++ b/src/app/scripts/FindMsgTopicsTab/FindMsgTopicsTab.tsx
@@ -19,6 +19,7 @@ import { AI } from '../appInsights';
 import { getTopLevelMessagesLastSynced, topLevelMessagesSyncKey } from "../db/Sync";
 import { DatabaseLogin, ExportImportComponents, getChannelMap, getInformation, IChannelInfo, IExportImportArgs, IExportImportState } from "../ui-jsx";
 import { db } from "../db/Database";
+import { currentLoginHintKey } from "../msteams-react-base-component-with-auth";
 
 
 declare type DropdownItemPropsKey = DropdownItemProps & { key: string };
@@ -288,6 +289,7 @@ export class FindMsgTopicsTab extends TeamsBaseComponent<never, IFindMsgTopicsTa
             groupId = teamOptions[teamIdx].key;
             channelId = channelOptions[teamIdx][channelIdx].key;
         }
+        sessionStorage.setItem(currentLoginHintKey, loginHint);
 
         this.setState({
             teamsInfo: {
@@ -402,6 +404,7 @@ export class FindMsgTopicsTab extends TeamsBaseComponent<never, IFindMsgTopicsTa
             state: {...this.state.exportImportState},
             translate: this.state.t,
             exportOptionAvailable: true,
+            exportTargetTables: [db.teams, db.channels, db.channelMessages, db.images, db.users, db.lastsync],
         }
 
         return (

--- a/src/app/scripts/about/FindMsgIndex.tsx
+++ b/src/app/scripts/about/FindMsgIndex.tsx
@@ -22,6 +22,7 @@ interface IFindMsgIndexState extends IMyOwnState {
 
 
 export class FindMsgIndex extends TeamsBaseComponentWithAuth {
+    protected exportTargetTables = undefined;
     protected exportOptionAvailable = true;
     protected isFixedPageSize = false;
     protected showInformation = false;

--- a/src/app/scripts/dateUtils.ts
+++ b/src/app/scripts/dateUtils.ts
@@ -16,6 +16,7 @@ export { default as startOfToday } from "date-fns/startOfToday";
 export { default as subDays } from "date-fns/subDays";
 export { default as subHours } from "date-fns/subHours";
 export { default as subMinutes } from "date-fns/subMinutes";
+export { default as subSeconds } from "date-fns/subSeconds";
 export { default as subMonths } from "date-fns/subMonths";
 export { default as subWeeks } from "date-fns/subWeeks";
 export { default as subYears } from "date-fns/subYears";

--- a/src/app/scripts/i18n/ICommonMessage.ts
+++ b/src/app/scripts/i18n/ICommonMessage.ts
@@ -51,14 +51,14 @@ export interface ICommonMessage {
     confirmExport: string;
     /** (画像エクスポートを省略すると時間が短縮されます。) */
     confirmExportOption: string;
-    /** {0}をエクスポート中... ( {1} / {2} ) {3}% 完了 */
-    exportProgress: (tableName: string, done: number, all: number, progress: number) => string;
+    /** エクスポート中... ( {0} / {1} ) {2}% 完了 */
+    exportProgress: (done: number, all: number, progress: number) => string;
     /** データベースにデータをインポートしますか？ */
     confirmImportForNewUser: string;
     /** One Driveに現在のデータよりも新しいファイルがエクスポートされています。インポートしますか？ */
     confirmImportNewerData: string;
-    /** {0}をインポート中... ( {1} / {2} ) {3}% 完了 */
-    importProgress: (tableName: string, done: number, all: number, progress: number) => string;
+    /** インポート中... ( {0} / {1} ) {2}% 完了 */
+    importProgress: (done: number, all: number, progress: number) => string;
     /** アプリの終了やタブの移動をしないでください。 */
     exportImportMessage: string;
     /** 処理を待機しています... */

--- a/src/app/scripts/i18n/messages_en.ts
+++ b/src/app/scripts/i18n/messages_en.ts
@@ -44,12 +44,12 @@ export const messages: IMessageTranslation = {
             `Do you want to export the data?\n
             This may take several minutes.`,
         confirmExportOption: `(time may be shorter if exclude images)`,
-        exportProgress: (tableName: string, done: number, all: number, progress: number) => `Exporting ${tableName}... ( ${done} / ${all} ) ${progress}% completed`,
+        exportProgress: (done: number, all: number, progress: number) => `Exporting ... ( ${done} / ${all} ) ${progress}% completed`,
         confirmImportForNewUser: `Do you want to import data to the database?`,
         confirmImportNewerData: 
             `there is a newer export data in the One Drive than current database.\n 
             Do you want to import?`,
-        importProgress: (tableName: string, done: number, all: number, progress: number) => `Importing ${tableName}.... ( ${done} / ${all} ) ${progress}% completed`,
+        importProgress: (done: number, all: number, progress: number) => `Importing ... ( ${done} / ${all} ) ${progress}% completed`,
         exportImportMessage: `Please do not close this application or move to other TAB.`,
         standingBy: `Standing-by for the process...`,
         yes: `yes`,

--- a/src/app/scripts/i18n/messages_ja.ts
+++ b/src/app/scripts/i18n/messages_ja.ts
@@ -44,12 +44,12 @@ export const messages: IMessageTranslation = {
             `最新データをエクスポートしますか？\n
             この処理は数分かかる可能性があります。`,
         confirmExportOption: `(画像エクスポートを省略すると時間が短縮されます)`,
-        exportProgress: (tableName: string, done: number, all: number, progress: number) => `${tableName}をエクスポート中... ( ${done} / ${all} ) ${progress}% 完了`,
+        exportProgress: (done: number, all: number, progress: number) => `エクスポート中... ( ${done} / ${all} ) ${progress}% 完了`,
         confirmImportForNewUser: `データベースにデータをインポートしますか？`,
         confirmImportNewerData: 
             `現在のデータよりも新しいエクスポートデータがあります。\n
             このデータをインポートしますか？`,
-        importProgress: (tableName: string, done: number, all: number, progress: number) => `${tableName}をインポート中.... ( ${done} / ${all} ) ${progress}% 完了`,
+        importProgress: (done: number, all: number, progress: number) => `インポート中... ( ${done} / ${all} ) ${progress}% 完了`,
         exportImportMessage: `アプリの終了やタブの移動をしないでください。`,
         standingBy: `処理を待機しています...`,
         yes: `はい`,

--- a/src/app/scripts/ui-jsx.tsx
+++ b/src/app/scripts/ui-jsx.tsx
@@ -187,6 +187,8 @@ export interface IExportImportArgs {
     translate: IMessageTranslation;
     /** エクスポート時に「画像をエクスポートするかどうか」を選択できるようにするにはtrueを設定してください */
     exportOptionAvailable: boolean;
+    /** エクスポート対象テーブル※省略すると全テーブルをエクスポート対象とします */
+    exportTargetTables?: Dexie.Table[];
 }
 
 /** エクスポート・インポートの確認ダイアログ、進捗状況マスクの制御用ステータス */
@@ -301,7 +303,7 @@ export const ExportImportComponents = (args: IExportImportArgs): JSX.Element => 
     const handleExportDialogOk = () => {
         args.state.exportDialog = false;
         args.state.exporting = true;
-        db.export({includeImages: args.state.exportImages, progressCallback: progressCallback, callback: exportCallback })
+        db.export({includeImages: args.state.exportImages, progressCallback: progressCallback, callback: exportCallback, targetTables: args.exportTargetTables })
         const newState = cloneState();
         args.otherCallback(newState);
     }
@@ -352,9 +354,9 @@ export const ExportImportComponents = (args: IExportImportArgs): JSX.Element => 
             res = args.translate.common.standingBy;
         } else {
             if (exporting) {
-                res = args.translate.common.exportProgress(processingTable, doneCount, allCount, currentProgress);
+                res = args.translate.common.exportProgress(doneCount, allCount, currentProgress);
             } else if (importing) {
-                res = args.translate.common.importProgress(processingTable, doneCount, allCount, currentProgress);
+                res = args.translate.common.importProgress(doneCount, allCount, currentProgress);
             }    
         }
         return res;


### PR DESCRIPTION
１．エクスポート対象テーブルを指定可能とした
  そもそものエクスポートの設計思想は、セキュリティ強化（ブラウザ等で使用したときに、他人のデータを
  参照できなくするためDBをクリアし、自身のデータでリストアする）を目的としたもので、DBの全テーブル
  を出力することを前提としていた。
　しかし、エクスポートの契機がタブにおける同期処理であることから、ユーザは当該タブで使用するデータ
  のみをエクスポートするものと思ってしまう。
  ※例：スケジュール検索タブでエクスポートするときにイメージを出力するかどうかを聞くと違和感を覚える
  このため、当該タブにおいてデータの整合性を保てる最低限のテーブルのみを指定してエクスポートすること
  を可能とした。

２．エクスポート/インポートの進捗表示を変更
  エクスポートの進捗表示はファイル出力のタイミングでテーブル・件数・進捗率を表示していたが、テーブル
  のレコードサイズによってファイル出力するまでのデータため込みの時間がまちまちであり、長時間進捗が
  動かないことがあった。かといってあまりに頻繁に進捗を更新するとレンダリングが割り込むため処理時間が
  伸びてしまう。このため、進捗は5%進むか前回更新から10秒以上経過したタイミングで更新するよう変更。
  また、プログラム内部名称はユーザには見せない方がよいという観点から、テーブル名の表示を廃止した。
  インポートの進捗表示も同様に、テーブル名の表示を廃止。

３．その他、軽微なバグ改修
  チャットメッセージ検索において、インポート後にチーム・チャネルのプルダウンが選択できない状態となって
  いたため修正。